### PR TITLE
[Bug] Alias of joined table in sorting mechanism

### DIFF
--- a/src/Services/DatabaseService.php
+++ b/src/Services/DatabaseService.php
@@ -182,6 +182,19 @@ class DatabaseService implements ServiceInterface
     }
 
     /**
+     * Find a model by its primary key.
+     *
+     * @param array    $identifiers
+     * @param string[] $columns
+     *
+     * @return Collection
+     */
+    public function findMany($identifiers, array $columns = ['*'])
+    {
+        return $this->repository->makeQuery()->findMany($identifiers, $columns);
+    }
+
+    /**
      * Returns total count of whole collection.
      *
      * @return int
@@ -210,8 +223,8 @@ class DatabaseService implements ServiceInterface
 
         $this->multiFilterBy($filter)->multiSortBy($sort);
 
-        $count = $this->instance->count();
         $items = $this->instance->forPage($page, $perPage)->get($columns);
+        $count = $this->instance->count();
 
         $options = [
             'path'  => $this->app->make('request')->url(),

--- a/src/Traits/Sortable.php
+++ b/src/Traits/Sortable.php
@@ -49,10 +49,12 @@ trait Sortable
 
         /** @var BelongsTo|HasOne $relationClass */
         $relationClass = $this->repository->makeModel()->$relation();
+        $sortByTable = $relationClass->getParent()->getTable();
 
         switch (get_class($relationClass)) {
             case BelongsTo::class:
-                $this->instance = $this->joinBelongsTo($relationClass);
+                $this->instance = $this->joinBelongsTo($relationClass, $relation);
+                $sortByTable = $relation;
                 break;
             case HasOne::class:
                 $this->instance = $this->joinHasOne($relationClass);
@@ -60,7 +62,7 @@ trait Sortable
         }
 
         $this->instance = $this->instance->select(DB::raw("{$relationClass->getParent()->getTable()}.*"))
-            ->orderBy("{$relationClass->getRelated()->getTable()}.{$column}", $direction);
+            ->orderBy("$sortByTable.{$column}", $direction);
 
         return $this;
     }
@@ -69,14 +71,15 @@ trait Sortable
      * Join a belongs to relationship.
      *
      * @param BelongsTo $relation
+     * @param string    $alias alias of joined table.
      *
      * @return mixed
      */
-    protected function joinBelongsTo(BelongsTo $relation)
+    protected function joinBelongsTo(BelongsTo $relation, $alias)
     {
-        return $this->instance->join(
-            $relation->getRelated()->getTable(),
-            $relation->getQualifiedOtherKeyName(),
+        return $this->instance->leftJoin(
+            $relation->getRelated()->getTable() . " as $alias",
+            "$alias.".$relation->getOtherKey(),
             '=',
             $relation->getQualifiedForeignKey()
         );

--- a/src/Traits/Sortable.php
+++ b/src/Traits/Sortable.php
@@ -49,7 +49,7 @@ trait Sortable
 
         /** @var BelongsTo|HasOne $relationClass */
         $relationClass = $this->repository->makeModel()->$relation();
-        $sortByTable = $relationClass->getParent()->getTable();
+        $sortByTable = $relationClass->getRelated()->getTable();
 
         switch (get_class($relationClass)) {
             case BelongsTo::class:


### PR DESCRIPTION
Adding possibility of sorting by relation many-to-one, self-referencing. For example, category has parent category in this relation. Parent category table has alias in joining it for sorting.
